### PR TITLE
[FEATURE] Add HasFailedSchedulerTask operation

### DIFF
--- a/Classes/Operation/HasFailedSchedulerTask.php
+++ b/Classes/Operation/HasFailedSchedulerTask.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WapplerSystems\ZabbixClient\Operation;
+
+/**
+ * This file is part of the "zabbix_client" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use WapplerSystems\ZabbixClient\OperationResult;
+
+/**
+ *
+ */
+class HasFailedSchedulerTask implements IOperation, SingletonInterface
+{
+
+    /**
+     *
+     * @param array $parameter None
+     * @return OperationResult
+     */
+    public function execute($parameter = [])
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_scheduler_task');
+        $count = $queryBuilder
+            ->count('uid')
+            ->from('tx_scheduler_task')
+            ->where(
+                $queryBuilder->expr()->neq('lastexecution_failure', $queryBuilder->createNamedParameter(''))
+                )
+            ->execute()
+            ->fetchColumn(0);
+
+        return new OperationResult(true, $count > 0);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -32,6 +32,7 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['zabbix_client']['operations'] = array_me
     'GetProgramVersion' => \WapplerSystems\ZabbixClient\Operation\GetProgramVersion::class,
     'GetFeatureValue' => \WapplerSystems\ZabbixClient\Operation\GetFeatureValue::class,
     'GetOpCacheStatus' => \WapplerSystems\ZabbixClient\Operation\GetOpCacheStatus::class,
+    'HasFailedSchedulerTask' => \WapplerSystems\ZabbixClient\Operation\HasFailedSchedulerTask::class,
 ]);
 
 if (version_compare(TYPO3_version, '9.0.0', '>=')) {


### PR DESCRIPTION
Not added to template.
Suggestion:

```xml
                  <item>
                    <name>TYPO3 scheduler failure</name>
                    <type>HTTP_AGENT</type>
                    <key>typo3_HasFailedSchedulerTask</key>
                    <delay>1h</delay>
                    <applications>
                        <application>
                            <name>TYPO3</name>
                        </application>
                    </applications>
                    <preprocessing>
                        <step>
                            <type>JSONPATH</type>
                            <params>$.value</params>
                        </step>
                    </preprocessing>
                    <url>https://{HOST.CONN}/zabbixclient/</url>
                    <query_fields>
                        <query_field>
                            <name>operation</name>
                            <value>HasFailedSchedulerTask</value>
                        </query_field>
                    </query_fields>
                    <posts>key={$TYPO3_CLIENT_KEY}</posts>
                    <request_method>POST</request_method>
                    <verify_peer>YES</verify_peer>
                    <triggers>
                        <trigger>
                            <expression>{str(true)}=0</expression>
                            <name>TYPO3 scheduler tasks failed</name>
                            <priority>AVERAGE</priority>
                            <type>MULTIPLE</type>
                        </trigger>
                    </triggers>
                </item>
```