### PR TITLE
Use extconf API

### DIFF
--- a/Classes/ManagerFactory.php
+++ b/Classes/ManagerFactory.php
@@ -9,6 +9,7 @@ namespace WapplerSystems\ZabbixClient;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WapplerSystems\ZabbixClient\Operation\IOperation;
 
@@ -38,7 +39,13 @@ class ManagerFactory
      */
     public function __construct()
     {
-        $this->extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['zabbix_client']);
+        if (version_compare(TYPO3_version, '9.0.0', '>=')) {
+            $this->extConf = GeneralUtility::makeInstance(
+                ExtensionConfiguration::class
+            )->get('zabbix_client');
+        } else {
+            $this->extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['zabbix_client']);
+        }
     }
 
     /**

--- a/Classes/Middleware/ZabbixClient.php
+++ b/Classes/Middleware/ZabbixClient.php
@@ -88,7 +88,7 @@ class ZabbixClient implements MiddlewareInterface
             }
         }
 
-        if ($result !== null) {
+        if (isset($result)) {
             return new JsonResponse($result->toArray());
         }
 


### PR DESCRIPTION
The extension configuration should be fetched using the API, see
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.0/Deprecation-82254-DeprecateGLOBALSTYPO3_CONF_VARSEXTextConf.html

Additionally using `isset` prevents an "undefined variable" error with PHP 8.