### PR TITLE
[TASK] Avoid undefined key error

### DIFF
--- a/Classes/Operation/GetInsecureExtensionList.php
+++ b/Classes/Operation/GetInsecureExtensionList.php
@@ -31,7 +31,7 @@ class GetInsecureExtensionList implements IOperation, SingletonInterface
      */
     public function execute($parameter = [])
     {
-        $scope = $parameter['scope'];
+        $scope = $parameter['scope'] ?? '';
 
         /** @var ListUtility $listUtility */
         $listUtility = GeneralUtility::makeInstance(ObjectManager::class)->get(ListUtility::class);

--- a/Classes/Operation/GetLogResults.php
+++ b/Classes/Operation/GetLogResults.php
@@ -52,7 +52,7 @@ class GetLogResults implements IOperation, SingletonInterface
     public function execute($parameter = [])
     {
 
-        $filter = $parameter['filter'];
+        $filter = $parameter['filter'] ?? '';
 
         $type = -1;
         $error = -1;

--- a/Classes/Operation/GetOutdatedExtensionList.php
+++ b/Classes/Operation/GetOutdatedExtensionList.php
@@ -31,7 +31,7 @@ class GetOutdatedExtensionList implements IOperation, SingletonInterface
      */
     public function execute($parameter = [])
     {
-        $scope = $parameter['scope'];
+        $scope = $parameter['scope'] ?? '';
 
         /** @var ListUtility $listUtility */
         $listUtility = GeneralUtility::makeInstance(ObjectManager::class)->get(ListUtility::class);

--- a/Classes/OperationManager.php
+++ b/Classes/OperationManager.php
@@ -41,10 +41,10 @@ class OperationManager implements IOperationManager
     public function getOperation($operationKey)
     {
         $operationKey = strtolower($operationKey);
-        if (is_string($this->operations[$operationKey])) {
+        if (is_string($this->operations[$operationKey] ?? null)) {
             return GeneralUtility::makeInstance($this->operations[$operationKey]);
         }
-        if (is_object($this->operations[$operationKey])) {
+        if (is_object($this->operations[$operationKey] ?? null)) {
             return $this->operations[$operationKey];
         }
         return false;


### PR DESCRIPTION
This patch avoids PHP 8 "undefined key" errors.

I needed this because I'm running a TYPO3 11 instance with PHP 8, so I cannot use the "v12" branch yet.