### PR TITLE
Fix detection of IPTC preservation in stripColorProfileParameters

### DIFF
--- a/Classes/Operation/HasIPTCPreservation.php
+++ b/Classes/Operation/HasIPTCPreservation.php
@@ -33,7 +33,9 @@ class HasIPTCPreservation implements IOperation, SingletonInterface
     public function execute(array $parameter = []): OperationResult
     {
         if (isset($GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters'])) {
-            return new OperationResult(true, (bool)array_search('!iptc', $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters'] ?? []) !== false);
+            foreach($GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters'] as $index => $key) {
+                if (strpos($key, '!iptc') !== false) return new OperationResult(true, true);
+            }
         }
         return new OperationResult(true, strpos($GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand'] ?? '','!iptc') !== false);
     }


### PR DESCRIPTION
See #48 
``array_search`` doesn't find partial strings in array values so it's necessary to iterate over the array and search with ``strpos``.